### PR TITLE
Fix compile issue

### DIFF
--- a/ESPTemplateProcessor.h
+++ b/ESPTemplateProcessor.h
@@ -109,6 +109,7 @@ class ESPTemplateProcessor {
         if(!silentSerial) {
           Serial.print("Failed to process '"); Serial.print(filePath); Serial.println("': Didn't reach the end of the file.");
         }
+        return false;
       }
     }
 


### PR DESCRIPTION
I added the return because otherwise the function would never have an output value and would continue in an infinite loop.

For this reason the library could not be compiled.